### PR TITLE
getUserFollows() now with the cursor param to paginate results

### DIFF
--- a/Instagram.php
+++ b/Instagram.php
@@ -265,6 +265,7 @@ class Instagram {
     /**
      * Get the list of users this user follows.
      * @param integer $id. The user id
+     * @param integer $cursor. Cursor to paginate results
      */
     public function getUserFollows($id, $cursor = '') {
         $endpointUrl = sprintf($this->_endpointUrls['user_follows'], $id, $this->getAccessToken(), $cursor);


### PR DESCRIPTION
The user_follows method doesn't returns all "follows", now the API accepts the cursor param to paginate through the API result.
